### PR TITLE
Add Event type available time

### DIFF
--- a/README.md
+++ b/README.md
@@ -55,6 +55,7 @@ Refer to the [Calendly API documentation](https://developer.calendly.com/api-doc
 |------------------------|----------|----------|--------|--------|
 | Event                  | ✓        | ✓        |        |        |
 | EventType              | ✓        | ✓        |        |        |
+| EventTypeAvailableTime | ✓        |          |        |        |
 | Guest                  | ✓        |          |        |        |
 | Invitee                | ✓        |          |        |        |
 | Organization           | ✓        |          |        |        |
@@ -88,7 +89,7 @@ The `$uuid` parameter referencing a user or organization uuid.
 ], $uuid, 'my-webhook-secret-key');
 ```
 
-To improve security, you can [sign your webhooks](https://developer.calendly.com/api-docs/ZG9jOjM2MzE2MDM4-webhook-signatures) 
+To improve security, you can [sign your webhooks](https://developer.calendly.com/api-docs/ZG9jOjM2MzE2MDM4-webhook-signatures)
 by providing the webhook secret key parameter.
 
 #### Webhook payload example

--- a/src/Models/BaseModel.php
+++ b/src/Models/BaseModel.php
@@ -39,7 +39,7 @@ abstract class BaseModel
     /**
      * Get resource model from uuid.
      *
-     * @return static
+     * @return static|null
      * @throws ApiErrorException|InvalidArgumentException|InternalServerErrorException
      */
     public static function get(string $uuid) {

--- a/src/Models/EventType.php
+++ b/src/Models/EventType.php
@@ -14,6 +14,7 @@ use LoBrs\Calendly\Traits\Timeable;
  * @property $slug
  * @property $scheduling_url
  * @property $duration
+ * @property $duration_options
  * @property $kind
  * @property $pooling_type
  * @property $type
@@ -23,6 +24,7 @@ use LoBrs\Calendly\Traits\Timeable;
  * @property $description_html
  * @property $secret
  * @property $booking_method
+ * @property $custom_questions
  * @property $deleted_at
  * @property $admin_managed
  * @property $locations

--- a/src/Models/EventType.php
+++ b/src/Models/EventType.php
@@ -24,6 +24,10 @@ use LoBrs\Calendly\Traits\Timeable;
  * @property $secret
  * @property $booking_method
  * @property $deleted_at
+ * @property $admin_managed
+ * @property $locations
+ * @property $position
+ * @property $locale
  */
 class EventType extends BaseModel
 {

--- a/src/Models/EventTypeAvailableTime.php
+++ b/src/Models/EventTypeAvailableTime.php
@@ -1,0 +1,21 @@
+<?php
+
+namespace LoBrs\Calendly\Models;
+
+use LoBrs\Calendly\Traits\Listable;
+
+/**
+ * An available meeting time slot for the given event type
+ *
+ * @see EventType
+ * @property string $status Indicates that the open time slot is "available"
+ * @property int $invitees_remaining Total remaining invitees for this available time. For Group Event Type, more than one invitee can book in this available time. For all other Event Types, only one invitee can book in this available time.
+ * @property string $start_time The moment the event was scheduled to start in UTC time
+ * @property string $scheduling_url The URL of the user’s scheduling site where invitees book this event type
+ */
+class EventTypeAvailableTime extends BaseModel
+{
+    public static string $resource = "event_type_available_times";
+
+    use Listable;
+}


### PR DESCRIPTION
Hello,

Thanks to share your work.

I added the object EventTypeAvailableTime considering this description : https://developer.calendly.com/api-docs/2d8d322931358-event-type-available-time

I made it Listable in order to access to this resource : https://developer.calendly.com/api-docs/6a1be82aef359-list-event-type-available-times

Tell me if you need more work from my side to merge this PR.

Regards,
Joël